### PR TITLE
Improve how page versions are displayed

### DIFF
--- a/src/css/breadcrumbs.css
+++ b/src/css/breadcrumbs.css
@@ -1,6 +1,5 @@
 .breadcrumbs {
   display: none;
-  flex: 1 1;
   padding: 0 0.5rem 0 0.75rem;
   line-height: var(--nav-line-height);
 }
@@ -29,7 +28,7 @@ a + .breadcrumbs {
 }
 
 .breadcrumbs li::after {
-  content: "/";
+  content: ">";
   padding: 0 0.5rem;
 }
 

--- a/src/css/page-versions.css
+++ b/src/css/page-versions.css
@@ -3,6 +3,7 @@
   margin-right: 0.7rem;
   position: relative;
   line-height: 1;
+  width: 5em;
 }
 
 @media screen and (min-width: 1024px) {

--- a/src/helpers/gt.js
+++ b/src/helpers/gt.js
@@ -1,0 +1,3 @@
+'use strict'
+
+module.exports = (a, b) => a > b

--- a/src/helpers/gte.js
+++ b/src/helpers/gte.js
@@ -1,0 +1,3 @@
+'use strict'
+
+module.exports = (a, b) => a >= b

--- a/src/helpers/lt.js
+++ b/src/helpers/lt.js
@@ -1,0 +1,3 @@
+'use strict'
+
+module.exports = (a, b) => a < b

--- a/src/helpers/lte.js
+++ b/src/helpers/lte.js
@@ -1,0 +1,3 @@
+'use strict'
+
+module.exports = (a, b) => a <= b

--- a/src/helpers/not-eq.js
+++ b/src/helpers/not-eq.js
@@ -1,0 +1,3 @@
+'use strict'
+
+module.exports = (a, b) => a !== b

--- a/src/partials/page-versions.hbs
+++ b/src/partials/page-versions.hbs
@@ -3,9 +3,11 @@
   <button class="version-menu-toggle" title="Show other versions of page">{{@root.page.componentVersion.displayVersion}}</button>
   <div class="version-menu">
     {{#each this}}
-    <a class="version
-      {{~#if (eq ./version @root.page.version)}} is-current{{/if~}}
-      {{~#if ./missing}} is-missing{{/if}}" href="{{{relativize ./url}}}">{{./displayVersion}}</a>
+      {{#if (lte @index 10)}}
+        <a class="version
+          {{~#if (eq ./version @root.page.version)}} is-current{{/if~}}
+          {{~#if ./missing}} is-missing{{/if}}" href="{{{relativize ./url}}}">{{./displayVersion}}</a>
+      {{/if}}
     {{/each}}
   </div>
 </div>


### PR DESCRIPTION
- Added Handlebars helpers for less than, greater than, and not equal
- Moved the page version selector closer to the breadcrumbs
- Increased the width of the page version selector to accommodate long versions