### PR TITLE
Add a cookie banner

### DIFF
--- a/src/css/cookie.css
+++ b/src/css/cookie.css
@@ -1,0 +1,23 @@
+.cookie-banner {
+  position: fixed;
+  display: none;
+  bottom: 0;
+  width: 100%;
+  padding: 20px 14px;
+  align-items: center;
+  justify-content: space-between;
+  background-color: var(--neutral-lighter);
+  border-radius: var(--border-radius);
+  border-top: 1px solid var(--primary);
+  z-index: 1000;
+}
+
+#cookie-close {
+  background-color: var(--accessibility-outline);
+  font-size: 1.2em;
+  border: none;
+  padding: 10px;
+  color: white;
+  border-radius: 2px;
+  cursor: pointer;
+}

--- a/src/css/site.css
+++ b/src/css/site.css
@@ -7,6 +7,7 @@
 @import "body.css";
 @import "nav.css";
 @import "clipboard.css";
+@import "cookie.css";
 @import "expanded-image.css";
 @import "feedback.css";
 @import "home.css";

--- a/src/js/12-cookie-banner.js
+++ b/src/js/12-cookie-banner.js
@@ -1,0 +1,14 @@
+;(function () {
+  'use strict'
+
+  var cookieBanner = document.getElementById('cookie')
+  var cookieButton = document.getElementById('cookie-close')
+
+  if (window.localStorage.getItem('docsCookie') !== 'closed') {
+    cookieBanner.style.display = 'flex'
+  };
+  cookieButton.addEventListener('click', function () {
+    cookieBanner.style.display = 'none'
+    window.localStorage.setItem('docsCookie', 'closed')
+  })
+})()

--- a/src/partials/cookie.hbs
+++ b/src/partials/cookie.hbs
@@ -1,0 +1,7 @@
+<div class='cookie-banner' id='cookie'>
+<p>
+    This website uses cookies to give you the best experience.
+    <a href=’https://hazelcast.com/privacy/’>Learn more</a>
+  </p>
+<button class='close' id='cookie-close'>Close</button>
+</div>

--- a/src/partials/header-content.hbs
+++ b/src/partials/header-content.hbs
@@ -54,4 +54,5 @@
       </div>
     </div>
   </nav>
+  {{> cookie}}
 </header>


### PR DESCRIPTION
Gives users a notice that the docs site uses cookies and links them to our privacy policy to learn more.

When a user clicks `close`, we create a localStorage name/value pair with name="docsCookie" and value="closed". We then check this on each page to display the banner only for those who haven't closed it.